### PR TITLE
Switch to use public HTTP endpoints

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "client"]
 	path = client
-	url = git@github.com:eProsima/Micro-XRCE-DDS-Client.git
+	url = https://github.com:eProsima/Micro-XRCE-DDS-Client.git
 [submodule "agent"]
 	path = agent
-	url = git@github.com:eProsima/Micro-XRCE-DDS-Agent.git
+	url = https://github.com:eProsima/Micro-XRCE-DDS-Agent.git
 [submodule "gen"]
 	path = gen
-	url = git@github.com:eProsima/Micro-XRCE-DDS-Gen.git
+	url = https://github.com:eProsima/Micro-XRCE-DDS-Gen.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "client"]
 	path = client
-	url = https://github.com:eProsima/Micro-XRCE-DDS-Client.git
+	url = https://github.com/eProsima/Micro-XRCE-DDS-Client.git
 [submodule "agent"]
 	path = agent
-	url = https://github.com:eProsima/Micro-XRCE-DDS-Agent.git
+	url = https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
 [submodule "gen"]
 	path = gen
-	url = https://github.com:eProsima/Micro-XRCE-DDS-Gen.git
+	url = https://github.com/eProsima/Micro-XRCE-DDS-Gen.git


### PR DESCRIPTION
The current `.submodules` file is causing an issue when instantiating within a Docker environment. See https://github.com/Fiware/tutorials.Fast-RTPS-Micro-RTPS/issues/5 - this can be simply fixed by using HTTP urls rather than SSH