### PR TITLE
Bump version number to 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ project(microxrcedds VERSION "2.0.0")
 
 set(_client_tag v2.0.0)
 set(_client_version 2.0.0)
-set(_agent_tag v2.0.0)
+set(_agent_tag develop)
 set(_gen_tag master)
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ endif()
 
 project(microxrcedds VERSION "2.0.0")
 
-set(_client_tag develop)
-set(_client_version 1.2.5)
-set(_agent_tag develop)
-set(_gen_tag develop)
+set(_client_tag v2.0.0)
+set(_client_version 2.0.0)
+set(_agent_tag v2.0.0)
+set(_gen_tag master)
 
 ###############################################################################
 # Build options.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 project(microxrcedds VERSION "2.0.0")
 
-set(_client_tag v2.0.0)
+set(_client_tag develop)
 set(_client_version 2.0.0)
 set(_agent_tag develop)
 set(_gen_tag master)


### PR DESCRIPTION
This should fail until https://github.com/eProsima/Micro-XRCE-DDS-Agent/pull/225 and https://github.com/eProsima/Micro-XRCE-DDS-Client/pull/207 are merged and tagged