### PR TITLE
Move CI from Jenkins to GitHub actions

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -64,6 +64,7 @@ jobs:
 
       # --- Run tests with newer CTest to produce JUnit ---
       - name: Run tests and export JUnit
+        if: always()
         shell: bash
         run: |
           ctest --test-dir build/microxrcedds-build/agent/src/agent-build \

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -51,6 +51,32 @@ jobs:
           cmake --version
           ctest --version
 
+      - name: Install vcan kernel module (Azure runner)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # Try to install the exact extra-mods package for the running kernel,
+          # fall back to the Azure meta-package if needed.
+          if ! sudo apt-get install -y "linux-modules-extra-$(uname -r)"; then
+            sudo apt-get install -y linux-modules-extra-azure
+          fi
+          # Load the module (no-op if already built-in or loaded)
+          sudo modprobe vcan || {
+            echo "::error::Failed to load vcan on kernel $(uname -r)"
+            exit 1
+          }
+
+      - name: Setup vcan0 for CAN tests
+        run: |
+          sudo modprobe vcan || true
+          # Create if missing; ok if already exists
+          if ! ip link show vcan0 >/dev/null 2>&1; then
+            sudo ip link add dev vcan0 type vcan
+          fi
+          sudo ip link set vcan0 mtu 72
+          sudo ip link set dev vcan0 up
+          ip -details link show vcan0
+
       - name: Configure
         run: |
           mkdir -p build

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -57,8 +57,8 @@ jobs:
 
           # CMake 3.31.8
           CMAKE_VER=3.31.8
-          curl -L "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" -o cmake-old.tgz
-          sudo tar -C /opt -xzf cmake-old.tgz
+          curl -L "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" -o cmake-${CMAKE_VER}.tgz
+          sudo tar -C /opt -xzf cmake-${CMAKE_VER}.tgz
           echo "/opt/cmake-${CMAKE_VER}-linux-x86_64/bin" >> "$GITHUB_PATH"
 
       - name: Show versions

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -1,0 +1,135 @@
+name: CI Linux
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Manual trigger"
+  schedule:
+    - cron: '25 20 * * 6'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build-test-style-cover:
+    name: Build, Tests, and Coverage
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Install CMake and prerequisites
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential curl python3-pip valgrind openjdk-8-jdk-headless
+          python3 -m pip install --upgrade pip
+          python3 -m pip install gcovr
+
+          # gradle install
+          wget https://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+          mkdir /opt/gradle
+          unzip -d /opt/gradle gradle-6.2.2-bin.zip
+          echo "/opt/gradle/gradle-6.2.2/bin" >> "$GITHUB_PATH"
+
+          # CMake 3.31.8
+          CMAKE_VER=3.31.8
+          curl -L "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" -o cmake-old.tgz
+          sudo tar -C /opt -xzf cmake-old.tgz
+          echo "/opt/cmake-${CMAKE_VER}-linux-x86_64/bin" >> "$GITHUB_PATH"
+
+      - name: Show cmake version
+        run: |
+          cmake --version
+          ctest --version
+
+      - name: Configure
+        run: |
+          mkdir -p build
+          cd build
+          cmake ../ci/linux -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: |
+          cd build
+          make -j"$(nproc)"
+
+      # --- Run tests with newer CTest to produce JUnit ---
+      - name: Run tests and export JUnit
+        shell: bash
+        run: |
+          ctest --test-dir build/microxrcedds-build/agent/src/agent-build \
+            --output-on-failure \
+            --no-tests=error \
+            --output-junit "$GITHUB_WORKSPACE/build/AgentCTestResults.xml"
+          ctest --test-dir build/microxrcedds-build/client/src/client-build \
+            --output-on-failure \
+            --no-tests=error \
+            --output-junit "$GITHUB_WORKSPACE/build/ClientCTestResults.xml"
+          ctest --test-dir build/microxrcedds-build/itests/src/itests-build \
+            --output-on-failure \
+            --no-tests=error \
+            --output-junit "$GITHUB_WORKSPACE/build/ITestsCTestResults.xml"
+
+      - name: Generate coverage (gcovr Cobertura XML + HTML)
+        shell: bash
+        run: |
+          EXCLUDES=(
+            '--exclude-unreachable-branches'
+            '--exclude' 'ci/'
+            '--exclude' 'test/'
+            '--exclude' '.*gtest.*' \
+            '--exclude' '.*gmock.*' \
+            '--exclude' '.*CMakeFiles.*' \
+            '--exclude' 'build/microxrcedds-build/temp_install/include/fastcdr.*' \
+            '--exclude' 'build/microxrcedds-build/agent/src/agent-build/temp_install/fastrtps.*' \
+            '--exclude' 'build/microxrcedds-build/agent/src/agent-build/temp_install/spdlog.*' \
+            '--exclude' 'build/microxrcedds-build/agent/src/agent-build/temp_install/fastcdr.*' \
+            '--exclude' '.*/ArgumentParser.*' \
+            '--exclude' '.*/AgentInstance.*' \
+            '--exclude' '.*/XRCETypes.*' \
+            '--exclude' '.*/xrce_types.*' \
+          )
+          gcovr -x -r . "${EXCLUDES[@]}" -o build/coverage.xml
+          gcovr --html-details -r . "${EXCLUDES[@]}" -o build/coverage.html
+          gcovr -r . "${EXCLUDES[@]}" # human-readable summary
+
+      - name: Upload artifacts (CTest & Coverage)
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-and-coverage
+          path: |
+            build/AgentCTestResults.xml
+            build/ClientCTestResults.xml
+            build/ITestsCTestResults.xml
+            build/coverage.xml
+            build/coverage.html
+          if-no-files-found: warn
+
+      - name: Publish unit test results (JUnit)
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: (!cancelled())
+        with:
+          files: |
+            build/AgentCTestResults.xml
+            build/ClientCTestResults.xml
+            build/ITestsCTestResults.xml
+          check_run: false
+          comment_mode: failures
+          comment_title: "Linux Tests Results"
+
+  uncrustify:
+    name: Uncrustify check
+    runs-on: ubuntu-22.04
+    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
+    steps:
+      - name: Run Uncrustify Linter
+        uses: eProsima/eProsima-CI/ubuntu/uncrustify@v0

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -26,6 +26,21 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
+      - name: Install vcan kernel module (Azure runner)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # Try to install the exact extra-mods package for the running kernel,
+          # fall back to the Azure meta-package if needed.
+          if ! sudo apt-get install -y "linux-modules-extra-$(uname -r)"; then
+            sudo apt-get install -y linux-modules-extra-azure
+          fi
+          # Load the module (no-op if already built-in or loaded)
+          sudo modprobe vcan || {
+            echo "::error::Failed to load vcan on kernel $(uname -r)"
+            exit 1
+          }
+
       - name: Install CMake and prerequisites
         shell: bash
         run: |
@@ -46,25 +61,12 @@ jobs:
           sudo tar -C /opt -xzf cmake-old.tgz
           echo "/opt/cmake-${CMAKE_VER}-linux-x86_64/bin" >> "$GITHUB_PATH"
 
-      - name: Show cmake version
+      - name: Show versions
         run: |
           cmake --version
           ctest --version
-
-      - name: Install vcan kernel module (Azure runner)
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          # Try to install the exact extra-mods package for the running kernel,
-          # fall back to the Azure meta-package if needed.
-          if ! sudo apt-get install -y "linux-modules-extra-$(uname -r)"; then
-            sudo apt-get install -y linux-modules-extra-azure
-          fi
-          # Load the module (no-op if already built-in or loaded)
-          sudo modprobe vcan || {
-            echo "::error::Failed to load vcan on kernel $(uname -r)"
-            exit 1
-          }
+          gcc --version
+          gcov --version
 
       - name: Setup vcan0 for CAN tests
         run: |
@@ -125,9 +127,11 @@ jobs:
             '--exclude' '.*/XRCETypes.*' \
             '--exclude' '.*/xrce_types.*' \
           )
-          gcovr -x -r . "${EXCLUDES[@]}" -o build/coverage.xml
-          gcovr --html-details -r . "${EXCLUDES[@]}" -o build/coverage.html
-          gcovr -r . "${EXCLUDES[@]}" # human-readable summary
+          IGNORE_ERR='--gcov-ignore-parse-errors=negative_hits.warn_once_per_file'
+
+          gcovr -x -r . "${EXCLUDES[@]}" $IGNORE_ERR -o build/coverage.xml
+          gcovr --html-details -r . "${EXCLUDES[@]}" $IGNORE_ERR -o build/coverage.html
+          gcovr -r . "${EXCLUDES[@]}" $IGNORE_ERR # human-readable summary
 
       - name: Upload artifacts (CTest & Coverage)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -1,0 +1,107 @@
+name: CI Windows
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Manual trigger"
+  schedule:
+    - cron: '25 20 * * 6'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build-and-tests:
+    name: Build and Tests
+    runs-on: windows-2022
+
+    env:
+      TOOLSET: v142
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Install CMake
+        uses: ssrobins/install-cmake@v1
+        with:
+          version: '3.31.8'
+
+      - name: Install OpenSSL and set env
+        shell: pwsh
+        run: |
+          choco install openssl --no-progress -y
+          $root = "C:\Program Files\OpenSSL-Win64"
+          echo "OPENSSL_ROOT_DIR=$root" >> $env:GITHUB_ENV
+          echo "$($root)\bin" >> $env:GITHUB_PATH
+
+      - name: Show tool versions
+        shell: pwsh
+        run: |
+          cmake --version
+          ctest --version
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          mkdir build
+          cd build
+          cmake ..\ci\windows `
+            -G "Visual Studio 17 2022" `
+            -A x64 `
+            -T $env:TOOLSET `
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        shell: pwsh
+        run: |
+          cd build
+          cmake --build . --config Release
+
+      - name: Run tests and export JUnit
+        shell: pwsh
+        run: |
+          ctest --test-dir build/uxrce/agent/src/agent-build `
+            -C Release `
+            --output-on-failure `
+            --no-tests=error `
+            --output-junit "$env:GITHUB_WORKSPACE/build/AgentCTestResults.xml"
+          ctest --test-dir build/uxrce/client/src/client-build `
+            -C Release `
+            --output-on-failure `
+            --no-tests=error `
+            --output-junit "$env:GITHUB_WORKSPACE/build/ClientCTestResults.xml"
+          ctest --test-dir build/uxrce/itests/src/itests-build `
+            -C Release `
+            --output-on-failure `
+            --no-tests=error `
+            --output-junit "$env:GITHUB_WORKSPACE/build/ITestsCTestResults.xml"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifact
+          path: |
+            build/AgentCTestResults.xml
+            build/ClientCTestResults.xml
+            build/ITestsCTestResults.xml
+          if-no-files-found: error
+
+      - name: Publish unit test results (JUnit)
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        if: (!cancelled())
+        with:
+          files: |
+            build/AgentCTestResults.xml
+            build/ClientCTestResults.xml
+            build/ITestsCTestResults.xml
+          check_run: false
+          comment_mode: failures
+          comment_title: "Windows Tests Results"


### PR DESCRIPTION
Migrate CI testing from eProsima's Jenkins infrastructure to GitHub actions.